### PR TITLE
Added a function to find a device which starts with a given name

### DIFF
--- a/dtree.c
+++ b/dtree.c
@@ -54,6 +54,24 @@ struct dtree_dev_t *dtree_byname(const char *name)
 	return curr;
 }
 
+struct dtree_dev_t *dtree_startbyname(const char *name)
+{
+	struct dtree_dev_t *curr = NULL;
+	int string_length = strlen(name);
+
+	if(name == NULL || string_length == 0)
+		return NULL;
+
+	while((curr = dtree_next()) != NULL) {
+		if(!strncmp(name, curr->name, string_length))
+			break;
+
+		dtree_dev_free(curr);
+	}
+
+	return curr;
+}
+
 static
 int is_compatible(const struct dtree_dev_t *dev, const char *compat)
 {

--- a/dtree.c
+++ b/dtree.c
@@ -54,16 +54,16 @@ struct dtree_dev_t *dtree_byname(const char *name)
 	return curr;
 }
 
-struct dtree_dev_t *dtree_startbyname(const char *name)
+struct dtree_dev_t *dtree_byname_prefix(const char *name_prefix)
 {
 	struct dtree_dev_t *curr = NULL;
-	int string_length = strlen(name);
+	int string_length = strlen(name_prefix);
 
-	if(name == NULL || string_length == 0)
+	if(name_prefix == NULL || string_length == 0)
 		return NULL;
 
 	while((curr = dtree_next()) != NULL) {
-		if(!strncmp(name, curr->name, string_length))
+		if(!strncmp(name_prefix, curr->name, string_length))
 			break;
 
 		dtree_dev_free(curr);

--- a/dtree.h
+++ b/dtree.h
@@ -138,9 +138,9 @@ struct dtree_dev_t *dtree_next(void);
 struct dtree_dev_t *dtree_byname(const char *name);
 
 /**
- * Look up for device which starts with the name.
+ * Look up for device which starts with the name prefix.
  * Returns the first occurence of device with the given
- * name.
+ * name prefix.
  * The entry should be free'd by dtree_dev_free().
  *
  * Uses shared internal iterator.
@@ -149,7 +149,7 @@ struct dtree_dev_t *dtree_byname(const char *name);
  * Returns NULL when not found or on error.
  * On error sets error state.
  */
-struct dtree_dev_t *dtree_startbyname(const char *name);
+struct dtree_dev_t *dtree_byname_prefix(const char *name_prefix);
 
 /**
  * Looks up for device compatible with the given type.

--- a/dtree.h
+++ b/dtree.h
@@ -138,6 +138,20 @@ struct dtree_dev_t *dtree_next(void);
 struct dtree_dev_t *dtree_byname(const char *name);
 
 /**
+ * Look up for device which starts with the name.
+ * Returns the first occurence of device with the given
+ * name.
+ * The entry should be free'd by dtree_dev_free().
+ *
+ * Uses shared internal iterator.
+ * To search from beginning call dtree_reset().
+ *
+ * Returns NULL when not found or on error.
+ * On error sets error state.
+ */
+struct dtree_dev_t *dtree_startbyname(const char *name);
+
+/**
  * Looks up for device compatible with the given type.
  * The entry should be free'd by dtree_dev_free().
  *


### PR DESCRIPTION
Added a function to find a device which starts with a given name.

The Xilinx Vivado and SDK creates a device tree file which contains the base address as a part of the name (e.g. "axi_bram_ctrl@6fff0000").
It is not possible to implement a general search for the base adresse of a device with "three byname(const char *name)" when the base address have to be part of the search string.